### PR TITLE
Fix small typo in link to starter notebook.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Demo notebooks
 This repository provides some simple live demos for SageMath and other
 software included in the SageMath distribution.
 
-- `index.ipynb <index.ipy>`_: starter notebook / brief SageMath demo
+- `index.ipynb <index.ipynb>`_: starter notebook / brief SageMath demo
 - `demo-gap.ipynb <demo-gap.ipynb>`_: brief GAP demo
 - `demo-pari.ipynb <demo-pari.ipynb>`_: brief Pari/GP demo
 - `demo-singular.ipynb <demo-singular.ipynb>`_: brief Singular demo


### PR DESCRIPTION
Typo results in a 404 on the first notebook (starter) in the "Demo notebooks" section of README.

In the meantime, thank you for putting together this conda-based SageMath environment for Binder! I was doing an example from a cryptography book that used SageMath, so this came in handy.

Found your work by way of discussion thread at https://discourse.jupyter.org/t/binder-and-sagemath/11059.